### PR TITLE
fix: resolve functional bugs in password generator

### DIFF
--- a/src/__tests__/PasswordEntropyCalculator.test.js
+++ b/src/__tests__/PasswordEntropyCalculator.test.js
@@ -65,4 +65,10 @@ describe('PasswordEntropyCalculator', () => {
 		const result8 = PasswordEntropyCalculator('abcdefgh')
 		expect(result8).toBeCloseTo(result4 * 2)
 	})
+
+	it('calculates entropy for password with emoji', () => {
+		const result = PasswordEntropyCalculator('a\ud83d\ude00')
+		const expected = Math.log2(26 * 3662) * 3
+		expect(result).toBeCloseTo(expected)
+	})
 })

--- a/src/__tests__/PasswordStrength.test.jsx
+++ b/src/__tests__/PasswordStrength.test.jsx
@@ -14,13 +14,13 @@ describe('PasswordStrength', () => {
 		expect(screen.getByText('STRENGTH')).toBeInTheDocument()
 	})
 
-	it('shows minimal filled bars for empty password', () => {
+	it('shows no filled bars for empty password', () => {
 		render(<PasswordStrength password="" />)
 		const bars = document.querySelectorAll('.grid-cols-10 span')
 		const filledBars = Array.from(bars).filter(
 			(bar) => bar.className && bar.className.includes('bg-gray-300')
 		)
-		expect(filledBars.length).toBeGreaterThan(0)
+		expect(filledBars.length).toBe(0)
 	})
 
 	it('shows some filled bars for a weak password', () => {

--- a/src/components/PasswordEntropyCalculator.js
+++ b/src/components/PasswordEntropyCalculator.js
@@ -11,9 +11,10 @@ export const PasswordEntropyCalculator = (password) => {
 		hasUppercase && 26,
 		hasNumber && 10,
 		hasSpecial && 33,
-		hasEmoji && 1
+		hasEmoji && 3662
 	].filter(Boolean)
 
-	// current max 426.41...
+	if (sets.length === 0) return 0
+
 	return Math.log2(sets.reduce((a, b) => a * b, 1)) * length
 }

--- a/src/components/PasswordGenerator.jsx
+++ b/src/components/PasswordGenerator.jsx
@@ -43,7 +43,7 @@ export default function PasswordGenerator() {
 					min='4'
 					max='24'
 					value={length}
-					onChange={(e) => setLength(e.target.value)}
+					onChange={(e) => setLength(Number(e.target.value))}
 					className='
 			form-range
 			appearance-none

--- a/src/components/PasswordStrength.jsx
+++ b/src/components/PasswordStrength.jsx
@@ -1,23 +1,23 @@
 import { PasswordEntropyCalculator } from './PasswordEntropyCalculator'
 
+const MAX_ENTROPY = 426
+const STRENGTH_BARS = 10
+
 export default function PasswordStrength({ password }) {
 	const BACKGROUND_COLOR_CHECKED = 'bg-gray-300'
 	const BACKGROUND_COLOR_UNCHECKED = 'bg-slate-900'
 
-	const entropyElements = 10
-	const entropy = (PasswordEntropyCalculator(password) * entropyElements) / 426
+	const entropy = (PasswordEntropyCalculator(password) * STRENGTH_BARS) / MAX_ENTROPY
 
 	const getBgEntropyElement = (index) => {
-		if (entropy >= index) {
-			return index <= entropy ? BACKGROUND_COLOR_CHECKED : BACKGROUND_COLOR_UNCHECKED
-		}
+		return entropy > index ? BACKGROUND_COLOR_CHECKED : BACKGROUND_COLOR_UNCHECKED
 	}
 
 	return (
 		<div className='w-full flex p-3 bg-slate-900'>
 			<span className='text-gray-500'>STRENGTH</span>
 			<span className='ml-auto text-gray-500 grid grid-cols-10 gap-2'>
-				{[...Array(entropyElements).keys()].reverse().map((value) => (
+				{[...Array(STRENGTH_BARS).keys()].map((value) => (
 					<span
 						key={value}
 						className={`h-5 w-2 border-gray-300 border-2 inline ${getBgEntropyElement(value)}`}


### PR DESCRIPTION
## Summary
Fixes 4 functional bugs across the password generator components.
## Bug Fixes
### 1. `length` stored as string instead of number
`PasswordGenerator.jsx:46` — `e.target.value` returns a string. Now converted with `Number()` before passing to `setLength()`.
### 2. `getBgEntropyElement` returns `undefined`
`PasswordStrength.jsx` — The function had a dead ternary branch and no fallback for low entropy values. Simplified to a single ternary with proper else branch.
### 3. Strength bars rendered right-to-left
`PasswordStrength.jsx:20` — `.reverse()` caused bars to fill from right to left. Removed so they fill left-to-right as expected.
### 4. Emoji pool size = 1 in entropy calculator
`PasswordEntropyCalculator.js:14` — Emoji pool was set to 1, making it useless. Updated to 3662 (approximate Unicode emoji count). Also added early return for empty passwords.
### Other improvements
- Extracted magic numbers to named constants (`MAX_ENTROPY`, `STRENGTH_BARS`)
- Updated tests to match corrected behavior (76 tests, all passing)