### PR TITLE
fix: add packageManager field and update workflows for Node.js 24

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
 
@@ -12,8 +15,7 @@ jobs:
   coverage:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 24

--- a/.github/workflows/deploy-to-vps.yml
+++ b/.github/workflows/deploy-to-vps.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Password Generator
 
-[![Deploy to VPS](https://github.com/dpuentel/password-generator/actions/workflows/deploy-to-vps.yml/badge.svg)](https://github.com/dpuentel/password-generator/actions/workflows/deploy-to-vps.yml)
+[![Deploy](https://github.com/dpuentel/password-generator/actions/workflows/deploy-to-vps.yml/badge.svg)](https://github.com/dpuentel/password-generator/actions/workflows/deploy-to-vps.yml)
 ![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/dpuentel/password-generator/main/coverage.json)
 
 You can test a **[demo here](https://password-generator.dpuentel.com/)**.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "password-generator",
+  "packageManager": "pnpm@11.1.3",
   "type": "module",
   "version": "0.0.1",
   "scripts": {


### PR DESCRIPTION
- Add packageManager pnpm@11.1.3 to package.json
- Update actions/checkout to v5 (Node.js 24 compatible)
- Remove pnpm/action-setup (no longer needed with packageManager)
- Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env to both workflows
- Fixes pnpm version error and Node.js 20 deprecation warnings