### PR TITLE
fix: add corepack enable to coverage-badge workflow

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: 24
           cache: "pnpm"
 
+      - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:coverage 2>&1 | tee coverage-output.txt
 


### PR DESCRIPTION
pnpm is not available on the runner by default. corepack enable reads the packageManager field from package.json and installs pnpm@11.1.3 automatically.