### PR TITLE
fix: use pnpm/action-setup with explicit version

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -19,9 +19,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.3
           cache: "pnpm"
 
-      - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:coverage 2>&1 | tee coverage-output.txt
 


### PR DESCRIPTION
corepack enable was not installing pnpm on the runner. Using pnpm/action-setup@v4 with version: 11.1.3 ensures pnpm is properly installed and cached.