### PR TITLE
fix: correct pnpm/action-setup cache parameter

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: "pnpm"
       - uses: pnpm/action-setup@v4
         with:
           version: 11.1.3
-          cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:coverage 2>&1 | tee coverage-output.txt


### PR DESCRIPTION
cache param in pnpm/action-setup@v4 expects boolean, not string. Moved cache: pnpm to actions/setup-node@v4 where it belongs. pnpm/action-setup only needs version: 11.1.3