### PR TITLE
fix: install pnpm before setup-node for cache to work

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.3
       - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: "pnpm"
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11.1.3
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:coverage 2>&1 | tee coverage-output.txt


### PR DESCRIPTION
actions/setup-node@v4 with cache: pnpm needs pnpm already installed to compute the cache key. Reorder: pnpm/action-setup first, then setup-node with cache.