### PR TITLE
feat: add CI workflow for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main"]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint:eslint
+
+  build:
+    name: Build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build


### PR DESCRIPTION
## Summary
Add GitHub Actions CI workflow that runs tests, lint, and build in parallel on every PR to `main`.
## Changes
- New `.github/workflows/ci.yml` with 3 parallel jobs: Test, Lint, Build
- Runs on `pull_request` to `main`
- Uses same runner setup as other workflows (ubuntu-24.04, pnpm@11.1.3, Node.js 24)
## Required manual step
After merging, configure branch protection in GitHub:
**Settings → Branches → Add rule → Pattern: `main`**
- ✅ Require status checks to pass before merging
- ✅ Select checks: `Test`, `Lint`, `Build`
This will block merging PRs if any check fails.