### PR TITLE
fix: keep copy button always on the right side

### DIFF
--- a/src/components/PasswordResult.jsx
+++ b/src/components/PasswordResult.jsx
@@ -36,7 +36,7 @@ export default function PasswordResult({ password, placeholder }) {
 		>
 			<span
 				onClick={handleSelect}
-				className={`text-lg ${passwordColor} ${isCopied ? 'underline' : ''} font-bold cursor-pointer select-all min-w-0 break-all`}
+				className={`text-lg ${passwordColor} ${isCopied ? 'underline' : ''} font-bold cursor-pointer select-all min-w-0 break-all grow`}
 				aria-live='polite'
 				aria-label={password ? 'Click to select password' : undefined}
 			>
@@ -44,7 +44,7 @@ export default function PasswordResult({ password, placeholder }) {
 			</span>
 			<button
 				onClick={handleCopy}
-				className='w-5 shrink-0 hover:text-gray-300'
+				className='w-5 shrink-0 hover:text-gray-300 ml-auto'
 				aria-label='Copy password to clipboard'
 			>
 				{hasError ? (


### PR DESCRIPTION
Add grow to password span and ml-auto to copy button so the button stays anchored to the right regardless of password length.