### PR TITLE
fix: handle integer coverage values in badge regex

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Extract coverage and generate badge
         run: |
-          COVERAGE=$(grep -E "^\s*All files" coverage-output.txt | grep -oP '\d+\.\d+' | head -1)
+          COVERAGE=$(grep -E "^\s*All files" coverage-output.txt | grep -oP '\d+(\.\d+)?' | head -1)
           COVERAGE_INT=$(echo "$COVERAGE" | cut -d. -f1)
 
           if [ "$COVERAGE_INT" -ge 90 ]; then


### PR DESCRIPTION
## Summary
Fix coverage badge showing `%` instead of actual percentage when coverage is 100%.
## Problem
The regex `\d+\.\d+` requires a decimal point, but 100% coverage is displayed as `100` (integer) in the vitest output, not `100.0`. This caused the grep to return empty, resulting in the badge showing just `%`.
## Fix
Changed regex from `\d+\.\d+` to `\d+(\.\d+)?` to match both integer (`100`) and decimal (`99.12`) values.